### PR TITLE
APP_THEME changed

### DIFF
--- a/push_swap_gui/app_gui.py
+++ b/push_swap_gui/app_gui.py
@@ -14,7 +14,7 @@ MIN_SIZE_X = 700
 MIX_SIZE_Y = 650
 
 WIN_TITLE = '42_push-swap'
-APP_THEME = 'aqua'
+APP_THEME = 'classic'
 
 TIPS_TEXT = """
 1) You may resize window, if you want!


### PR DESCRIPTION
If u try to launch your application not on mac os:
> Traceback (most recent call last):
>   File "/home/positivedespair/anaconda3/bin/push_swap_gui", line 11, in <module>
>     sys.exit(main())
>   File "/home/positivedespair/anaconda3/lib/python3.7/site-packages/push_swap_gui/__main__.py", line 10, in main
>     app_gui.PushSwapGUI(master)
>   File "/home/positivedespair/anaconda3/lib/python3.7/site-packages/push_swap_gui/app_gui.py", line 36, in __init__
>     self.style.theme_use(APP_THEME)
>   File "/home/positivedespair/anaconda3/lib/python3.7/site-packages/ttk.py", line 544, in theme_use
>     self.tk.call("ttk::setTheme", themename)
> _tkinter.TclError: can't find package ttk::theme::aqua

So I changed the APP_THEME to multiplatform value